### PR TITLE
Adjusted PHE to now fire off messages whenever 'TOURNAMENT:updated' i…

### DIFF
--- a/TO_BE_IMPLEMENTED/index.js
+++ b/TO_BE_IMPLEMENTED/index.js
@@ -1,0 +1,67 @@
+const chalk = require('chalk');
+
+const error = chalk.bold.red;
+const warning = chalk.keyword('orange');
+
+const preflop = chalk.black.bgWhite;
+
+const childProcess = require("child_process");
+
+let preflop_done = false;
+let num_players = 3;
+let players_contacted = 0;
+
+const startT = () => {
+    const thread = childProcess.fork("tournament.js");
+
+    console.log(chalk.blue.bgWhite("Thread created!"));
+    thread.on("message", (msg) => {
+        if (msg.topic === "exit") {
+            thread.kill();
+        }
+        else if (msg.topic == "updates") {
+            console.log(preflop('Index.js | out of set up.| '));
+
+            //msg.data.ante = 25;
+            //t.pause();
+            console.log('->', msg.data);
+            console.log(chalk.bgMagenta('------------------------------------------'));
+
+            if (!preflop_done) {
+                thread.send({ topic: "go-preflop" });
+                setup_done = true;
+            }
+
+            else if (players_contacted < num_players) {
+
+                players_contacted++;
+                console.log(warning("Index.js | msg players ... Currently : " + (players_contacted) + "/3"))
+                if (players_contacted < num_players - 1) {
+                    thread.send({ topic: "go-preflop" });
+                }
+                else {
+                    //enter FLOP.
+                    thread.send({ topic: "go-flop" });
+                }
+            }
+            else {
+                console.log(warning("Index.js | pausing..."));
+                thread.send({ topic: "debug pause" });
+            }
+
+            console.log("Here");
+
+        }
+        else {
+            setup = msg.topic;
+            //console.log(setup);
+            thread.send({ topic: "debug pause" });
+
+        }
+    })
+
+    thread.send({ topic: "create" });
+
+}
+
+startT();

--- a/TO_BE_IMPLEMENTED/phe_loop1.js
+++ b/TO_BE_IMPLEMENTED/phe_loop1.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const States = require("../domain/tournament/states");
+
+const { Tasks02 } = require("./tasks.js");
+
+/**
+ * @name loop
+ * @this {Tournament}
+ */
+async function loop1(LOGGER) {
+  // `loop` never returns until
+  // current tournament isn't complete.
+  while (this.state !== States.get("completed")) {
+    for (const task of Tasks02) {
+
+      if (task.shouldRun(this)) {
+        LOGGER.debug("[TASK]: " + task.name);
+        await task.run(LOGGER, this);
+      }
+    }
+  }
+}
+
+module.exports = loop1;

--- a/TO_BE_IMPLEMENTED/phe_tasks.js
+++ b/TO_BE_IMPLEMENTED/phe_tasks.js
@@ -1,0 +1,139 @@
+"use strict";
+
+const resetGamestate = require("./tasks/setup/reset-gamestate");
+const assignDealerButton = require("./tasks/setup/assign-dealer-button");
+const setBlind = require("./tasks/setup/update-small-blind");
+const payAnte = require("./tasks/setup/pay-ante");
+const payBlinds = require("./tasks/setup/pay-blind");
+const assignPrivateCards = require("./tasks/setup/assign-private-cards");
+const saveSetup = require("./tasks/setup/save-setup");
+
+const setupTable = [
+  resetGamestate,
+
+  // Assign the dealer button;
+  // only an active players can receive the button.
+  assignDealerButton,
+
+  // Update blind level.
+  setBlind,
+
+  payAnte,
+
+  // Players next to the Dealer
+  // pay small/big blind amount.
+  payBlinds,
+
+  assignPrivateCards,
+
+  // TODO log (debug) cards assigned to each player.
+
+  // Make sure the gamestate
+  // is persisted somewhere.
+  saveSetup,
+];
+
+const preFlop = require("./tasks/game/pre-flop");
+const makePostFlopTask = require("./tasks/game/make-post-flop-task");
+const recap = require("./tasks/game/recap");
+
+const playHand = [
+  // Ask each player to cover the big blind,
+  // then uncover three common cards.
+  preFlop,
+
+  // Ask each player their bet,
+  // then uncover a new common card.
+  makePostFlopTask("FLOP"),
+
+  makePostFlopTask("TURN"),
+
+  makePostFlopTask("RIVER"),
+
+  recap,
+];
+
+const prepareHandRank = require("./tasks/teardown/rank-hand");
+const assignPot = require("./tasks/teardown/assign-pot");
+const updateGameRank = require("./tasks/teardown/update-game-rank");
+
+const showdown = [
+  // Create the rank of the current hand.
+  // On the basis of this ranking players
+  // will get chips from the pot.
+  prepareHandRank,
+
+  assignPot,
+
+  updateGameRank,
+];
+
+const warmup = require("./tasks/warmup-wait");
+const onGameCompleted = require("./tasks/on-game-completed");
+const waitOnPause = require("./tasks/wait-restart");
+const waitBeforeHand = require("./tasks/throttle");
+const announceCurrentHand = require("./tasks/announce-hand");
+const incrementHandId = require("./tasks/next-hand");
+const announceTournamentEnd = require("./tasks/announce-end");
+
+//Goes up to SET UP.
+const Tasks01 = [
+  warmup,
+  onGameCompleted,
+  waitOnPause,
+  waitBeforeHand,
+  announceCurrentHand,
+  ...setupTable
+]
+
+//Game rounds.
+const Tasks02 = [
+  // It's a collection of tasks
+  // focused on the dynamics of a hand.
+  ...playHand,
+]
+
+const Tasks = [
+  warmup,
+
+  // Before a new hand starts,
+  // the engine checks the active players.
+  // If there is only one active player,
+  // and all the others are out,
+  // the current game is finished.
+  // TODO
+  onGameCompleted,
+
+  // Before a new hand starts,
+  // checks if game is on pause.
+  waitOnPause,
+
+  waitBeforeHand,
+
+  announceCurrentHand,
+
+  // It's a collection of tasks
+  // focused on creating the condition
+  // to play a new hand.
+  // Eg. Pay blind, assign cards...
+  ...setupTable,
+
+  // It's a collection of tasks
+  // focused on the dynamics of a hand.
+  ...playHand,
+
+  // It's a collection of tasks
+  // focused on the completion of an hand.
+  // Determine the winner, assign the pot...
+  ...showdown,
+
+  incrementHandId,
+
+  announceTournamentEnd,
+];
+
+module.exports = {
+  Tasks,
+  Tasks01,
+  Tasks02
+}

--- a/TO_BE_IMPLEMENTED/tournament.js
+++ b/TO_BE_IMPLEMENTED/tournament.js
@@ -1,0 +1,79 @@
+const Tournament = require("poker-holdem-engine");
+
+const tournamentID = 'tester';
+const mongoUri = "mongodb://localhost:9001/store"
+
+const chalk = require('chalk');
+
+const error = chalk.bold.red;
+const warning = chalk.keyword('orange');
+
+const preflop = chalk.black.bgWhite;
+
+const players = [
+    {
+        "id": "pA",
+        "name": "Person A",
+        "serviceUrl": "sample-url-1"
+    },
+    {
+        "id": "pC",
+        "name": "Person C",
+        "serviceUrl": "sample-url-1"
+    },
+    {
+        "id": "pB",
+        "name": "Person B",
+        "serviceUrl": "sample-url-1"
+    }
+
+];
+const tournamentSettings = {
+    "BUYIN": 100,
+    "WARMUP": false,
+    "WARMUP_GAME": 10,
+    "WARMUP_TIME": 10,
+    "HAND_THROTTLE_TIME": 1,
+    "SMALL_BLINDS": [50, 100, 200, 250],
+    "SMALL_BLINDS_PERIOD": 1,
+    "PAY_ANTE_AT_HAND": 1,
+    "MAX_GAMES": 1,
+    "POINTS": [
+        [10, 2, 0, 0]
+    ]
+};
+
+let t;
+process.on("message", (msg) => {
+    console.log(chalk.cyan('Tournament.js | Checking msg topic: ', msg.topic))
+    switch (msg.topic) {
+        case "create":
+            console.log("Got 'create'! ,, creating...")
+            t = new Tournament(tournamentID, players, tournamentSettings, { autoStart: true });
+            t.on("TOURNAMENT:updated", (data, done) => {
+                console.log(chalk.bgCyan('Tournament | Updated!'));
+                t.pause();
+
+                process.send({ topic: "updates", data });
+
+            });
+            break;
+        case "go-preflop":
+            console.log(chalk.cyan(" Tournament.js | PRE-FLOP |case restart |  Restarting!  "));
+            t.restart();
+            break;
+        case "go-flop": {
+            console.log(chalk.cyan("Tournament.js | FLOP | Restarting "));
+            t.restart();
+        }
+        case "debug pause":
+            t.pause();
+            console.log(chalk.bgMagenta("PAUSED"));
+            break;
+        default:
+            console.log(`Index.js | [${msg.topic}] ----- ${msg.message}...`)
+    }
+})
+
+
+


### PR DESCRIPTION
This update allows Tournament updates to be fired out to the index.js

Index.js
Please implement replace the contents in Slackbot's '/start' with the items in index.js

Tournament.js
Tournament.js's updates are mainly listeners to different commands

phe_loop1.js
This one can be placed next to PHE's loop.js + rename to loop1.js when done. It's not a very elegant solution right now. We should look into refactoring this, and merging it with the original loop.

phe_tasks.js
The contents of this file can replace all codes in the original PHE/tasks.js.
The main changes are breaking the single Task array into multiple of them.

Also:
Please add the following lines to poker-holdem-engine/tournament.js:
Under start() :
```
  async restart() {
    if (this.state === States.get("paused")) {
      LOGGER.info(`Tournament ${this.id} is going to restart.`, { tag: this.id });

      this.state = States.get("active");
    }
    return loop1.call(this, LOGGER);
  }
```
and
under ```const loop = require("./engine/loop");```
add ```const loop1 = require("./engine/loop.1");```